### PR TITLE
Adding a space after Semi-colons

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,10 @@
         "php": "~5.5.0|~5.6.0|~7.0.0"
     },
 
-    "authors":[
+    "authors": [
         {
-            "name":"Fabian Schmengler",
-            "email":"fs@integer-net.de"
+            "name": "Fabian Schmengler",
+            "email": "fs@integer-net.de"
         }
     ],
     "autoload": {


### PR DESCRIPTION
This throws a Failed assertion in magento's test. 

"Coding style: a space is necessary after colon."

This should shut it up.