### PR TITLE
Use case insensitive comparison

### DIFF
--- a/Plugin/CreateMissingAttributeOptionPlugin.php
+++ b/Plugin/CreateMissingAttributeOptionPlugin.php
@@ -114,7 +114,7 @@ class CreateMissingAttributeOptionPlugin
     {
         $attributeOptionList = $this->attributeOptionManagementInterface->getItems($attributeCode);
         foreach ($attributeOptionList as $attributeOptionInterface) {
-            if (strcmp($attributeOptionInterface->getLabel(), $label) === 0) {
+            if (strcasecmp($attributeOptionInterface->getLabel(), $label) === 0) {
                 return $attributeOptionInterface;
             }
         }


### PR DESCRIPTION
During the import, attribute option labels are matched case-insensitive. Hence, we should do the same.