### PR TITLE
Add PHP 8.x compatibility to PHP constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "magento2-module",
     "description": "Extended Import Features (ported from AvS_FastSimpleImport)",
     "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0"
+        "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0|~8.0.0|~8.1.0"
     },
 
     "authors": [


### PR DESCRIPTION
Seems fine;

```
$ vendor/bin/phpcs -p vendor/firegento/extendedimport --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility --extensions=php,phtml --runtime-set testVersion 8.0 
..... 5 / 5 (100%)

Time: 161ms; Memory: 12MB

$ vendor/bin/phpcs -p vendor/firegento/extendedimport --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility --extensions=php,phtml --runtime-set testVersion 8.1
..... 5 / 5 (100%)

Time: 167ms; Memory: 12MB
```