### PR TITLE
allow composer installation with php 8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "magento2-module",
     "description": "Extended Import Features (ported from AvS_FastSimpleImport)",
     "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0|~8.0.0|~8.1.0"
+        "php": "^5.5.0|^7.0.0|^8.0.0"
     },
 
     "authors": [


### PR DESCRIPTION
This pull request is intended to make it possible to install the extension with Magento 2.4.6 and PHP 8.2, I did not test the actual compatibility of the module with PHP 8.2.